### PR TITLE
Smarter startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ dev:
 		-e DOCKER_HOST=http://192.168.59.103:2375 \
 		-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
 		-e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
-		$(NAME) /bin/route53-registrator -metadata=192.168.59.103:5000 -container=test -zone=Z1P7DHMHEAX6O3 -cname=cluster-registry.realtime.bnservers.com -logtostderr=1
+		$(NAME) /bin/route53-registrator -metadata=192.168.59.103:5000 -container=test -zone=Z1P7DHMHEAX6O3 -cname=cluster-registry.realtime.bnservers.com -logtostderr=1 -healthCheckPort=1000 -healthCheckEndpoint=/status
 
 
 build/container: clean stage/route53-registrator Dockerfile

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -14,11 +14,6 @@ type HealthCheckFQDN struct {
 	HealthCheckID string
 }
 
-type ResourceRecordHealthCheck struct {
-	ResourceRecordSet route53.ResourceRecordSet
-	HealthCheck       route53.HealthCheck
-}
-
 //Creates the Config required for a health check, including some
 //default values
 func createHealthCheckInput(uniqueId *string, fqdn *string, port int64, resourcepath *string) (input *route53.CreateHealthCheckInput, err error) {

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -5,8 +5,6 @@ import (
 	"github.com/awslabs/aws-sdk-go/service/route53"
 	"github.com/golang/glog"
 	"github.com/nu7hatch/gouuid"
-	"strings"
-	"time"
 )
 
 type HealthCheckFQDN struct {
@@ -131,4 +129,19 @@ func CreateHealthCheckIfMissing(client *route53.Route53, fqdn string, port int64
 	}
 	glog.Infof("Found a matching health check for FQDN %s and port %v", fqdn, port)
 	return healthCheckFqdn.HealthCheckID, nil
+}
+
+func DeleteHealthCheck(client *route53.Route53, healthCheckId string) (err error) {
+	_, err = client.DeleteHealthCheck(&route53.DeleteHealthCheckInput{
+		HealthCheckID: aws.String(healthCheckId),
+	})
+	if awserr := aws.Error(err); awserr != nil {
+		// A service error occurred.
+		glog.Errorf("AWS Error: \n Code: %s \n Message: %s", awserr.Code, awserr.Message)
+		return err
+	} else if err != nil {
+		// A non-service error occurred.
+		return err
+	}
+	return nil
 }

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -46,8 +46,6 @@ func HealthCheckForFQDNPort(client *route53.Route53, fqdn string, port *int64) (
 	//per fqdn/port
 	for _, healthcheck := range resp.HealthChecks {
 		config := healthcheck.HealthCheckConfig
-		glog.Infof("%v", *config.FullyQualifiedDomainName)
-		glog.Infof("%v", fqdn)
 		if *config.FullyQualifiedDomainName == fqdn {
 			if *config.Port == *port {
 				return true, HealthCheckFQDN{

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -1,0 +1,103 @@
+package healthcheck
+
+import (
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/aws/awsutil"
+	"github.com/awslabs/aws-sdk-go/service/route53"
+	"github.com/golang/glog"
+	"github.com/nu7hatch/gouuid"
+)
+
+type HealthCheckFQDN struct {
+	Fqdn          string
+	HealthCheckID string
+}
+
+//Creates the Config required for a health check, including some
+//default values
+func createHealthCheckInput(uniqueId *string, fqdn *string, port int64, resourcepath *string) (input *route53.CreateHealthCheckInput, err error) {
+	config := route53.HealthCheckConfig{
+		FailureThreshold:         aws.Long(1),
+		FullyQualifiedDomainName: fqdn,
+		RequestInterval:          aws.Long(10),
+		ResourcePath:             resourcepath,
+		Type:                     aws.String("HTTP"),
+		Port:                     aws.Long(port),
+	}
+
+	//caller references have to be unique on every request
+	callerrerference, err := uuid.NewV4()
+	if err != nil {
+		return nil, nil
+	}
+	return &route53.CreateHealthCheckInput{
+		CallerReference:   aws.String(callerrerference.String()),
+		HealthCheckConfig: &config,
+	}, nil
+}
+
+//given a domain name, check if it there is a healthcheck for it.
+func HealthCheckForFQDNPort(client *route53.Route53, fqdn string, port *int64) (exists bool, check HealthCheckFQDN, err error) {
+	resp, err := client.ListHealthChecks(&route53.ListHealthChecksInput{})
+	if awserr := aws.Error(err); awserr != nil {
+		// A service error occurred.
+		glog.Errorf("AWS Error: \n Code: %s \n Message: %s", awserr.Code, awserr.Message)
+		panic(err)
+	} else if err != nil {
+		// A non-service error occurred.
+		glog.Errorf("Error occured creating records: \n %s", err)
+		panic(err)
+	}
+	// Pretty-print the response data.
+	glog.Infof(awsutil.StringValue(resp))
+
+	//check if any of them contain the healthcheck
+	//assumption is that there will be a unique health check
+	//per fqdn/port
+	for _, healthcheck := range resp.HealthChecks {
+		config := healthcheck.HealthCheckConfig
+		glog.Infof("%v", *config.FullyQualifiedDomainName)
+		glog.Infof("%v", fqdn)
+		if *config.FullyQualifiedDomainName == fqdn {
+			if *config.Port == *port {
+				return true, HealthCheckFQDN{
+					Fqdn:          *healthcheck.HealthCheckConfig.FullyQualifiedDomainName,
+					HealthCheckID: *healthcheck.ID,
+				}, nil
+			}
+		} else {
+			glog.Infof("No string match")
+		}
+	}
+	return false, HealthCheckFQDN{}, nil
+}
+
+//Create a Health Check.
+func CreateHealthCheck(client *route53.Route53, hostname *string, port int64, resourcePath *string, fqdn *string) (check HealthCheckFQDN, err error) {
+	input, err := createHealthCheckInput(hostname, fqdn, port, resourcePath)
+	if err != nil {
+		return HealthCheckFQDN{}, err
+	}
+	resp, err := client.CreateHealthCheck(input)
+
+	if awserr := aws.Error(err); awserr != nil {
+		// A service error occurred.
+		glog.Errorf("AWS Error: \n Code: %s \n Message: %s", awserr.Code, awserr.Message)
+		panic(err)
+	} else if err != nil {
+		// A non-service error occurred.
+		glog.Errorf("Error occured creating records: \n %s", err)
+		panic(err)
+	}
+
+	return HealthCheckFQDN{
+		Fqdn:          *fqdn,
+		HealthCheckID: *resp.HealthCheck.ID,
+	}, nil
+}
+
+//Given a set of resource record sets, find all the health checks that haven't
+//passed recently. If they're older than 10 minutes, then delete them
+func findUnhealthyRecords(client *route53.Route53, fqdn string) (records []route53.ResourceRecordSet, err error) {
+	return nil, nil
+}

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -2,15 +2,21 @@ package healthcheck
 
 import (
 	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/aws/awsutil"
 	"github.com/awslabs/aws-sdk-go/service/route53"
 	"github.com/golang/glog"
 	"github.com/nu7hatch/gouuid"
+	"strings"
+	"time"
 )
 
 type HealthCheckFQDN struct {
 	Fqdn          string
 	HealthCheckID string
+}
+
+type ResourceRecordHealthCheck struct {
+	ResourceRecordSet route53.ResourceRecordSet
+	HealthCheck       route53.HealthCheck
 }
 
 //Creates the Config required for a health check, including some
@@ -38,20 +44,9 @@ func createHealthCheckInput(uniqueId *string, fqdn *string, port int64, resource
 
 //given a domain name, check if it there is a healthcheck for it.
 func HealthCheckForFQDNPort(client *route53.Route53, fqdn string, port *int64) (exists bool, check HealthCheckFQDN, err error) {
-	resp, err := client.ListHealthChecks(&route53.ListHealthChecksInput{})
-	if awserr := aws.Error(err); awserr != nil {
-		// A service error occurred.
-		glog.Errorf("AWS Error: \n Code: %s \n Message: %s", awserr.Code, awserr.Message)
-		panic(err)
-	} else if err != nil {
-		// A non-service error occurred.
-		glog.Errorf("Error occured creating records: \n %s", err)
-		panic(err)
-	}
-	// Pretty-print the response data.
-	glog.Infof(awsutil.StringValue(resp))
+	resp, err := getHealthChecks(client)
 
-	//check if any of them contain the healthcheck
+	//check if any of them contain the healthcheck.
 	//assumption is that there will be a unique health check
 	//per fqdn/port
 	for _, healthcheck := range resp.HealthChecks {
@@ -97,7 +92,73 @@ func CreateHealthCheck(client *route53.Route53, hostname *string, port int64, re
 }
 
 //Given a set of resource record sets, find all the health checks that haven't
-//passed recently. If they're older than 10 minutes, then delete them
-func findUnhealthyRecords(client *route53.Route53, fqdn string) (records []route53.ResourceRecordSet, err error) {
-	return nil, nil
+//passed recently. If they're older than 30 seconds, then delete them
+func FindFailingHealthChecks(client *route53.Route53, identifier string) (checks []*route53.HealthCheck, err error) {
+	resp, _ := getHealthChecks(client)
+	var failing []*route53.HealthCheck
+	for _, check := range resp.HealthChecks {
+		//get the tags
+		listTagsResp, _ := getTagsForHealthCheck(client, check.ID)
+		//find the tag with the expected key, and check it's value
+		for _, tag := range listTagsResp.ResourceTagSet.Tags {
+			if *tag.Key == "route53-registrator" {
+				//if the healthcheck is managed by *this* registrator (identified by a tag on the health check), then add it to the list of the failing health checks
+				if *tag.Value == identifier {
+					resp, err := client.GetHealthCheckStatus(&route53.GetHealthCheckStatusInput{
+						HealthCheckID: check.ID,
+					})
+					if awserr := aws.Error(err); awserr != nil {
+						// A service error occurred.
+						glog.Errorf("AWS Error: \n Code: %s \n Message: %s", awserr.Code, awserr.Message)
+						panic(err)
+					} else if err != nil {
+						// A non-service error occurred.
+						glog.Errorf("Error occured finding healthcheck status: \n %s", err)
+						panic(err)
+					}
+					for _, observation := range resp.HealthCheckObservations {
+						if strings.Contains(*observation.StatusReport.Status, "Failure") {
+							//only return those that have been unhealthy for 30 seconds
+							if observation.StatusReport.CheckedTime.Before(time.Now().Add(time.Duration(30) * time.Second)) {
+								glog.Infof("Healthcheck with matching tag failed over 30 seconds ago: ", *observation.StatusReport.Status)
+								failing = append(failing, check)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return failing, nil
+}
+
+func getHealthChecks(client *route53.Route53) (out route53.ListHealthChecksOutput, err error) {
+	resp, err := client.ListHealthChecks(&route53.ListHealthChecksInput{})
+	if awserr := aws.Error(err); awserr != nil {
+		// A service error occurred.
+		glog.Errorf("AWS Error: \n Code: %s \n Message: %s", awserr.Code, awserr.Message)
+		panic(err)
+	} else if err != nil {
+		// A non-service error occurred.
+		glog.Errorf("Error occured creating records: \n %s", err)
+		panic(err)
+	}
+	return *resp, nil
+}
+
+func getTagsForHealthCheck(client *route53.Route53, healthcheckId *string) (out route53.ListTagsForResourceOutput, err error) {
+	resp, err := client.ListTagsForResource(&route53.ListTagsForResourceInput{
+		ResourceID:   healthcheckId,
+		ResourceType: aws.String("healthcheck"),
+	})
+	if awserr := aws.Error(err); awserr != nil {
+		// A service error occurred.
+		glog.Errorf("AWS Error: \n Code: %s \n Message: %s", awserr.Code, awserr.Message)
+		panic(err)
+	} else if err != nil {
+		// A non-service error occurred.
+		glog.Errorf("Error occured finding tags: \n %s", err)
+		panic(err)
+	}
+	return *resp, nil
 }

--- a/main.go
+++ b/main.go
@@ -283,6 +283,7 @@ func main() {
 				}
 				if exists {
 					weightedRequestForClientZone("DELETE", healthCheckId, *cname, hostname(*metadataIP))
+					healthcheck.DeleteHealthCheck(client, healthCheckId)
 				} else {
 					glog.Infof("Suitable record doesn't exist. Not deleting")
 				}

--- a/main.go
+++ b/main.go
@@ -277,7 +277,6 @@ func main() {
 				if err != nil {
 					glog.Errorf("Error deleting route")
 				}
-				//don't pass the healthcheck id here; the record should be deleted even if the healthcheck doesn't exist
 				exists, err := recordExists(client, *zoneId, *cname, hostname(*metadataIP))
 				if err != nil {
 					glog.Errorf("Error checking for existing container: %v", err)

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -39,7 +38,6 @@ func containerIsRunning(client *dockerapi.Client, containerName string) (running
 	found := false
 	for _, container := range containers {
 		for _, name := range container.Names {
-			fmt.Println(normalizedContainerName(name), normalizedContainerName(containerName))
 			if normalizedContainerName(name) == normalizedContainerName(containerName) {
 				found = true
 				break

--- a/main.go
+++ b/main.go
@@ -217,6 +217,7 @@ func main() {
 	if err != nil {
 		glog.Errorf("Error checking for existing health check: %s", err)
 	}
+
 	//create one if there isn't
 	if !exists {
 		glog.Infof("No healthcheck found for endpoint. Creating.")
@@ -229,7 +230,7 @@ func main() {
 	}
 
 	//if the container is running, then check if there is an existing record pointing
-	//to this host. If there is not, then create one
+	//to this host. If there is not, then create one.
 	if running {
 		matchingResourceRecords, err := findMatchingResourceRecordsByName(client, *zoneId, *cname)
 		exists := false


### PR DESCRIPTION
Lots of changes in here:
- If the observed container is already up when the process starts, then check for an existing CNAME record. If it doesn't exist, then create it.
- Create a healthcheck for the DNS record. This is configured via command line parameters. The healthcheck is created on startup and removed when the record is deleted.
- Account for strange states when creating and deleting records. For instance, if the CNAME record already exists when the container starts up, then don't bother trying to create it again. Likewise, if it doesn't exist when the container dies, then don't try and delete it.
- Associate a tag with each of the Healthchecks. This isn't really used, but might be useful to know which healthchecks were created by the registrator.

@geowa4 @jamiemccrindle @Colin-Murphy @kdelemme 
